### PR TITLE
feat(privacy): add privacy toggle for posts and boards

### DIFF
--- a/backend/controllers/boardsController.js
+++ b/backend/controllers/boardsController.js
@@ -275,7 +275,6 @@ module.exports = {
                 { new: true }
             );
 
-            console.log("Board updated successfully:", updatedBoard._id);
             return res.json({ success: true, board: updatedBoard });
 
         } catch (err) {

--- a/backend/controllers/postsController.js
+++ b/backend/controllers/postsController.js
@@ -351,6 +351,14 @@ const sharePost = async (req, res) => {
       return res.status(404).json({ success: false, message: "Post not found" });
     }
 
+    // Verificar si el post es privado
+    if (post.privacy === "private") {
+      return res.status(403).json({ 
+        success: false, 
+        message: "Private posts cannot be shared. Please change the post to public first." 
+      });
+    }
+
     if (!post.shareToken) {
       post.shareToken = crypto.randomBytes(16).toString('hex');
     }
@@ -393,6 +401,14 @@ const getSharedPost = async (req, res) => {
 
     if (!post) {
       return res.status(404).json({ success: false, message: "Post not found or link disabled" });
+    }
+
+    // Verificar si el post es privado
+    if (post.privacy === "private") {
+      return res.status(403).json({ 
+        success: false, 
+        message: "This post is private and cannot be shared" 
+      });
     }
 
     const sectionsInfo = await Section.find({

--- a/frontend/public/src/css/posts.css
+++ b/frontend/public/src/css/posts.css
@@ -322,10 +322,24 @@ body {
 @keyframes fadeIn {
     from {
         opacity: 0;
+        transform: scale(0.8);
     }
 
     to {
         opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    to {
+        opacity: 0;
+        transform: scale(0.8);
     }
 }
 
@@ -2825,20 +2839,32 @@ body.modal-open {
     font-weight: 600 !important;
     text-transform: uppercase !important;
     letter-spacing: 0.5px !important;
-    cursor: default !important;
+    cursor: pointer !important;
     transition: all 0.2s ease !important;
+    background: none !important;
+    border: none !important;
 }
 
-.PrivacyPublic {
+.toggle-privacy-btn.PrivacyPublic {
     background-color: #e8f5e8 !important;
     color: #2e7d2e !important;
     border: 1px solid #a8d5a8 !important;
 }
 
-.PrivacyPrivate {
+.toggle-privacy-btn.PrivacyPrivate {
     background-color: #ffeaa7 !important;
     color: #6c5500 !important;
     border: 1px solid #ddc760 !important;
+}
+
+.toggle-privacy-btn.PrivacyPublic:hover {
+    background-color: #d4edd4 !important;
+    transform: scale(1.05) !important;
+}
+
+.toggle-privacy-btn.PrivacyPrivate:hover {
+    background-color: #ffd97d !important;
+    transform: scale(1.05) !important;
 }
 
 .TagReadOnly {
@@ -2959,6 +2985,10 @@ body.modal-open {
     100% {
         transform: scale(1);
     }
+}
+
+.toggle-privacy-btn:active {
+    transform: scale(0.95) !important;
 }
 
 .CardControls .IconButton .material-icons {
@@ -3743,4 +3773,157 @@ RECENT COMMENTS STYLES
 .Categories {
     margin-top: 0 !important;
     padding-top: 0 !important;
+}
+
+/* ==================== Share Modal Redesign ==================== */
+.ShareModalContent {
+    max-width: 480px !important;
+    padding: 40px 30px !important;
+    text-align: center;
+    animation: modalSlideIn 0.3s ease;
+}
+
+.ShareModalClose {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: transparent;
+    border: none;
+    font-size: 28px;
+    color: var(--TextColorSecondary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ShareModalClose:hover {
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--TextColorPrimary);
+    transform: rotate(90deg);
+}
+
+.ShareModalIcon {
+    width: 64px;
+    height: 64px;
+    margin: 0 auto 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 8px 16px rgba(102, 126, 234, 0.3);
+}
+
+.ShareModalIcon .material-icons {
+    font-size: 32px;
+    color: white;
+}
+
+.ShareModalTitle {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--TextColorPrimary);
+    margin-bottom: 10px;
+}
+
+.ShareModalDescription {
+    font-size: 14px;
+    color: var(--TextColorSecondary);
+    margin-bottom: 30px;
+    line-height: 1.5;
+}
+
+.ShareLinkBox {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 25px;
+    padding: 12px;
+    background: var(--bg-accent);
+    border: 2px solid var(--border-primary);
+    border-radius: 12px;
+    transition: all 0.3s ease;
+}
+
+.ShareLinkBox:focus-within {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+}
+
+.ShareLinkInput {
+    flex: 1;
+    padding: 10px 12px;
+    border: none;
+    background: transparent;
+    color: var(--TextColorPrimary);
+    font-size: 14px;
+    font-family: 'Courier New', monospace;
+    outline: none;
+}
+
+.ShareCopyBtn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.ShareCopyBtn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(102, 126, 234, 0.4);
+}
+
+.ShareCopyBtn:active {
+    transform: translateY(0);
+}
+
+.ShareCopyBtn .material-icons {
+    font-size: 18px;
+}
+
+.ShareModalFooter {
+    padding-top: 20px;
+    border-top: 1px solid var(--border-primary);
+}
+
+.ShareModalHint {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--TextColorSecondary);
+    margin: 0;
+}
+
+.ShareModalHint .material-icons {
+    font-size: 18px;
+    color: #667eea;
+}
+
+@media (max-width: 768px) {
+    .ShareModalContent {
+        padding: 30px 20px !important;
+    }
+    
+    .ShareModalTitle {
+        font-size: 20px;
+    }
+    
+    .ShareCopyText {
+        display: none;
+    }
 }

--- a/frontend/public/src/html/posts.html
+++ b/frontend/public/src/html/posts.html
@@ -271,32 +271,31 @@
     </button>
 
     <div id="ShareModal" class="ModalOverlay" style="display: none;">
-        <div class="ModalContent" style="max-width: 500px;">
-            <div class="ModalHeader">
-                <h2 class="ModalTitle" id="shareModalTitle">Share Post</h2>
-                <button class="CloseButton" onclick="closeShareModal()">×</button> <!-- ← Universal -->
+        <div class="ModalContent ShareModalContent">
+            <button class="CloseButton ShareModalClose" onclick="closeShareModal()">×</button>
+            
+            <div class="ShareModalIcon">
+                <span class="material-icons">share</span>
             </div>
-            <div class="ModalBody">
-                <p id="shareModalDescription" style="margin-bottom: 15px; color: #666;">
-                    Anyone with this link can view this post.
+            
+            <h2 class="ShareModalTitle" id="shareModalTitle">Share Post</h2>
+            <p class="ShareModalDescription" id="shareModalDescription">
+                Anyone with this link can view this post.
+            </p>
+
+            <div class="ShareLinkBox">
+                <input type="text" id="shareLinkInput" readonly class="ShareLinkInput">
+                <button class="ShareCopyBtn" onclick="copyShareLink()" title="Copy Link">
+                    <span class="material-icons">content_copy</span>
+                    <span class="ShareCopyText">Copy</span>
+                </button>
+            </div>
+
+            <div class="ShareModalFooter">
+                <p class="ShareModalHint">
+                    <span class="material-icons">info</span>
+                    Put your post in private mode to disable sharing.
                 </p>
-
-                <div class="ShareLinkContainer" style="display: flex; gap: 10px; margin-bottom: 20px;">
-                    <input type="text" id="shareLinkInput" readonly
-                        style="flex: 1; padding: 10px; border: 1px solid #ddd; border-radius: 8px; background: #f5f5f5;">
-                    <button class="PrimaryBtn" onclick="copyShareLink()" title="Copy Link">
-                        <span class="material-icons">content_copy</span>
-                    </button>
-                </div>
-
-                <div style="display: flex; justify-content: flex-end;">
-                    <button id="revokeLinkBtn" class="EditableActionButton"
-                        style="background-color: #ffebee; color: #d32f2f; border: none; display: none;"
-                        onclick="revokeShareLink()">
-                        <span class="material-icons">link_off</span>
-                        Disable Link
-                    </button>
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request introduces significant improvements to privacy controls and sharing functionality for posts and boards, as well as a visual redesign of the share modal and privacy toggle buttons. The changes enforce privacy rules at both the backend and frontend, ensuring private items cannot be shared, and provide a more interactive and visually appealing user interface for privacy and sharing actions.

**Key changes:**

### Privacy and Sharing Logic

* Backend controllers now prevent sharing or accessing share links for private posts, returning appropriate HTTP errors if attempted. [[1]](diffhunk://#diff-a72165424976dd3105e2c190e46af88063d443cafea9c30ceb3c12615e61dc67R354-R361) [[2]](diffhunk://#diff-a72165424976dd3105e2c190e46af88063d443cafea9c30ceb3c12615e61dc67R406-R413)
* The frontend only displays the share button for public posts and boards, and removes or adds the button dynamically when privacy is toggled. [[1]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccR473-R477) [[2]](diffhunk://#diff-fa412175c1e11622945669f9d2557073dcd3951ee6c879be2d0622ed911254d9R351-R355)
* New frontend logic allows users to toggle the privacy of posts and boards with a button, updating the UI and backend accordingly, and automatically invalidates share links when switching to private. [[1]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccR702-R710) [[2]](diffhunk://#diff-fa412175c1e11622945669f9d2557073dcd3951ee6c879be2d0622ed911254d9R407-R415) [[3]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccR1551-R1643)

### UI/UX Improvements

* The share modal has been visually redesigned with new classes, improved layout, and animations for a more modern look and better usability. [[1]](diffhunk://#diff-2d9148f569bff77e5932a8d1c50270b5ac9b6898c58ace257f58f434988c3586L274-R298) [[2]](diffhunk://#diff-143669675463980aab84e8137884f0d2ca62721373c174dec989943ca558951fR3777-R3929)
* Privacy toggle buttons are now styled as interactive buttons with hover and active states, replacing static spans for better accessibility and feedback. [[1]](diffhunk://#diff-143669675463980aab84e8137884f0d2ca62721373c174dec989943ca558951fL2828-R2869) [[2]](diffhunk://#diff-143669675463980aab84e8137884f0d2ca62721373c174dec989943ca558951fR2990-R2993) [[3]](diffhunk://#diff-fa412175c1e11622945669f9d2557073dcd3951ee6c879be2d0622ed911254d9L316-R321) [[4]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccL423-R428)

### Animations and Visual Feedback

* Added `fadeIn` and `fadeOut` keyframe animations for smooth appearance/disappearance of share buttons and modal elements. [[1]](diffhunk://#diff-143669675463980aab84e8137884f0d2ca62721373c174dec989943ca558951fR325-R342) [[2]](diffhunk://#diff-143669675463980aab84e8137884f0d2ca62721373c174dec989943ca558951fR2990-R2993)
* When privacy is changed, the share button animates in or out accordingly for a seamless user experience.

### Code Cleanup and Refactoring

* Removed obsolete code related to share link revocation buttons in the modal, simplifying the modal logic. [[1]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccL1462) [[2]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccL1494) [[3]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccL1528)
* Refactored share modal logic to use universal functions for both posts and boards, and exported these for cross-file usage. [[1]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccL1446-R1461) [[2]](diffhunk://#diff-01ea0f7f33ca63021555e2dee38b0d419f54750ffcf22e9d43911cc67d6f87ccR1675-R1680)

### Minor Improvements

* Removed unnecessary console logging in the backend board update controller.

These changes collectively enhance privacy enforcement, improve the user interface, and streamline the codebase for easier maintenance.